### PR TITLE
Choose oldest root node

### DIFF
--- a/src/EpiCategories/Extensions/IContentRepositoryExtensions.cs
+++ b/src/EpiCategories/Extensions/IContentRepositoryExtensions.cs
@@ -32,7 +32,7 @@ namespace Geta.EpiCategories.Extensions
                 LanguageLoaderOption.FallbackWithMaster()
             };
 
-            var rootCategory = contentRepository.GetChildren<CategoryRoot>(parentLink, loaderOptions).FirstOrDefault();
+            var rootCategory = contentRepository.GetChildren<CategoryRoot>(parentLink, loaderOptions).OrderBy(root => root.ContentLink.ID).FirstOrDefault();
 
             if (rootCategory != null)
             {


### PR DESCRIPTION
This is an update that adds a little logic to get the root node for the case where multiple have been created due to an import/export bug that is pasted below. This isn't really a fix for that bug but a band-aid to suppress the behavior of said bug.

https://world.optimizely.com/forum/developer-forum/CMS/Thread-Container/2022/3/geta-categories-bug-when-using-importexport-tool/